### PR TITLE
Support for https URIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ GeminaboxRelease.patch(:use_config => true)
 
 Then you will get a rake inabox:release task.
 
+If your geminabox server is using SSL/TLS, but you have an untrusted certificate, you can use the option `ssl_dont_verify`.
+
+E.g.
+
+```ruby
+require 'geminabox-release'
+GeminaboxRelease.patch(:host => "https://localhost:4000", :ssl_dont_verify => true)
+```
+
+However, that is _NOT_ recommended.
+
 
 If you wish to remove the bundler/gem_tasks rake release task, you can by adding `:remove_release` to the patch options:
 

--- a/geminabox-release.gemspec
+++ b/geminabox-release.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.files         = Dir["lib/**/*"]
-  spec.files        += [".gitignore", ".ruby-version", "Gemfile", "geminabox-release.gemspec", "README.md", "Rakefile", "LICENSE"]
+  spec.files        += [".gitignore", "Gemfile", "geminabox-release.gemspec", "README.md", "Rakefile", "LICENSE"]
   spec.require_paths = ["lib"]
 
 end

--- a/lib/geminabox-release.rb
+++ b/lib/geminabox-release.rb
@@ -54,7 +54,7 @@ module GeminaboxRelease
       raise GeminaboxRelease::NoHost
     end
     if options[:ssl_dont_verify]
-      @ssl_verify = options[:ssl_dont_verify]
+      @ssl_dont_verify = options[:ssl_dont_verify]
     end
 
     Bundler::GemHelper.class_eval do

--- a/lib/geminabox-release.rb
+++ b/lib/geminabox-release.rb
@@ -1,5 +1,5 @@
 require 'uri'
-require 'net/http'
+require 'net/https'
 
 module GeminaboxRelease
 
@@ -122,6 +122,7 @@ module GeminaboxRelease
         post_body << "\r\n--#{boundary}--\r\n\r\n"
 
         http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = (uri.scheme == 'https')
         req = Net::HTTP::Post.new(uri.request_uri)
         req.body = post_body.join
         req.basic_auth(username, password) unless username.nil? || username.empty?

--- a/lib/geminabox-release.rb
+++ b/lib/geminabox-release.rb
@@ -41,6 +41,8 @@ module GeminaboxRelease
     begin
     if options[:host]
       @host = options[:host]
+    elsif options[:ssl_dont_verify]
+      @ssl_verify = options[:ssl_dont_verify]
     elsif options[:use_config]
       require 'yaml'
       raise GeminaboxRelease::NoConfigFile unless File.exist?(File.expand_path("~/.gem/geminabox"))
@@ -123,6 +125,7 @@ module GeminaboxRelease
 
         http = Net::HTTP.new(uri.host, uri.port)
         http.use_ssl = (uri.scheme == 'https')
+        http.verify_mode = OpenSSL::SSL::VERIFY_NONE if @ssl_dont_verify
         req = Net::HTTP::Post.new(uri.request_uri)
         req.body = post_body.join
         req.basic_auth(username, password) unless username.nil? || username.empty?

--- a/lib/geminabox-release/version.rb
+++ b/lib/geminabox-release/version.rb
@@ -1,4 +1,4 @@
 module GeminaboxRelease
-	VERSION = "0.1.2"
+	VERSION = "0.1.3"
 end
 


### PR DESCRIPTION
Hi

We have a geminabox server on a SSL secured site, so my little patch here is to make that work (as well as with regular http scheme).

The `.ruby-version` was not in the repo, so including that in the gemspec broke the build on a fresh checkout. Furthermore it should not be there anyhow - The gem is supposed to run on any ruby version, right?

FYI, it _does_ work with basic auth :smile: 

/Hilli