### PR TITLE
Improve support for Basic Authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # ide
 .idea/
+pkg/
 

--- a/README.md
+++ b/README.md
@@ -16,25 +16,35 @@ You must no longer require "bundler/gem_tasks" as geminabox-release requires a m
 
 ## How to use
 
-Simply load this gem and patch with your geminabox URL in your Rakefile. 
-
-E.g.
+Simply load this gem and patch with your geminabox URL in your Rakefile:
 
 ```ruby
 require 'geminabox-release'
 GeminaboxRelease.patch(:host => "http://localhost:4000")
-
 ```
 
-or use your geminabox config file (YAML file with key :host and host url as value in ~/.gem/geminabox)
+Then you will get a rake `inabox:release` task.
 
+If your server requires basic authentication for the deployment, you can specify `:username` and `:password` as well.
+
+### Global Defaults
+
+You can store global defaults in `~/.gem/geminabox`, for instance:
+```yaml
+:host: "http://localhost:4000"
+:username: "peter.pan"
+:password: "secret"
+```
+Apply them by passing the `:use_config` flag:
 ```ruby
 require 'geminabox-release'
 GeminaboxRelease.patch(:use_config => true)
 
 ```
 
-Then you will get a rake inabox:release task.
+If an attribute is present in the global configuration, and also passed to the `GeminaboxRelease.patch` call, the latter takes precedence.
+
+### SSL
 
 If your geminabox server is using SSL/TLS, but you have an untrusted certificate, you can use the option `ssl_dont_verify`.
 
@@ -47,6 +57,7 @@ GeminaboxRelease.patch(:host => "https://localhost:4000", :ssl_dont_verify => tr
 
 However, that is _NOT_ recommended.
 
+### Bundler's `release` Task
 
 If you wish to remove the bundler/gem_tasks rake release task, you can by adding `:remove_release` to the patch options:
 
@@ -55,11 +66,7 @@ GeminaboxRelease.patch(:remove_release => true)
 
 ```
 
-
 **Ensure you do not _require "bundler/gem_tasks"_ in your rakefile anymore!**
-
-The gem (theoretically) supports basic auth like geminabox in the host address. e.g. http://username:password@localhost:4000
-It's untested as we didn't need it. Feel free to try it.
 
 
 ### Additional tasks

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Then you will get a rake `inabox:release` task.
 
 If your server requires basic authentication for the deployment, you can specify `:username` and `:password` as well.
 
+For reasons of compatibility, you can still specify the credentials in the `:host` option (e.g. `http://username:password@localhost:4000`), in which case
+they take precedence over the other parameters.
+
 ### Global Defaults
 
 You can store global defaults in `~/.gem/geminabox`, for instance:

--- a/lib/geminabox-release.rb
+++ b/lib/geminabox-release.rb
@@ -50,6 +50,18 @@ module GeminaboxRelease
     @config[:ssl_dont_verify]
   end
 
+  # extract credentials from a) our options and b) the given URI
+  def self.credentials(uri)
+    username = GeminaboxRelease.username
+    password = GeminaboxRelease.password
+    
+    unless uri.user.nil? || uri.user.empty?
+      username = URI.unescape uri.user
+      password = URI.unescape uri.password
+    end
+    [username, password]
+  end
+
   def self.patch(options = {})
     begin
     attribute_options = [:host, :username, :password, :ssl_dont_verify]
@@ -110,7 +122,7 @@ module GeminaboxRelease
       def inabox_push(path, force = false)
         uri = URI.parse(GeminaboxRelease.host)
 
-        username, password = credentials(uri)
+        username, password = GeminaboxRelease.credentials(uri)
 
         uri.path = uri.path + "/" unless uri.path.end_with?("/")
         uri.path += "upload"
@@ -155,18 +167,6 @@ module GeminaboxRelease
         else
           raise "Error (#{response.code} received)\n\n#{response.body}"
         end
-      end
-
-      # extract credentials from a) our options and b) the given URI
-      def credentials(uri)
-        username = GeminaboxRelease.username
-        password = GeminaboxRelease.password
-        
-        unless uri.user.nil? || uri.user.empty?
-          username = URI.unescape uri.user
-          password = URI.unescape uri.password
-        end
-        [username, password]
       end
 
     end  # end of class_eval

--- a/lib/geminabox-release.rb
+++ b/lib/geminabox-release.rb
@@ -160,15 +160,11 @@ module GeminaboxRelease
       # extract credentials from a) our options and b) the given URI
       def credentials(uri)
         username = GeminaboxRelease.username
-        if username.nil?
-          username = uri.user
-          username = URI.unescape username unless username.nil?
-        end
-
         password = GeminaboxRelease.password
-        if password.nil?
-          password = uri.password
-          password = URI.unescape password unless password.nil?
+        
+        unless uri.user.nil? || uri.user.empty?
+          username = URI.unescape uri.user
+          password = URI.unescape uri.password
         end
         [username, password]
       end

--- a/lib/geminabox-release/version.rb
+++ b/lib/geminabox-release/version.rb
@@ -3,6 +3,6 @@ module GeminaboxRelease
         # bundler >= 1.0.14 actually is a dependency
 	# Version 0.2.0
 	# * @hilli added support for https with optional veriy_none mode
-	VERSION = "1.0.1"
+	VERSION = "1.1.0"
 end
 

--- a/lib/geminabox-release/version.rb
+++ b/lib/geminabox-release/version.rb
@@ -3,6 +3,6 @@ module GeminaboxRelease
         # bundler >= 1.0.14 actually is a dependency
 	# Version 0.2.0
 	# * @hilli added support for https with optional veriy_none mode
-	VERSION = "1.0.0"
+	VERSION = "1.0.1"
 end
 


### PR DESCRIPTION
implemented the following changes:
- when `username`/`password` are specified in the `:host` parameter, they're unescaped (yes, I'm using `%` as part of my current password :))
- both `username` and `password` can now also be passed separately. This was necessary since otherwise, both would have been printed out on several occasions (for instance in a `rake --tasks` call.)
- options from `~/.gem/geminabox` are now always read, if `:use_config` is specified. Parameters to `patch` still overrule these global defaults.